### PR TITLE
fix some logical nodes missing due to return name type

### DIFF
--- a/logic/logic_nodes.py
+++ b/logic/logic_nodes.py
@@ -108,7 +108,7 @@ class Eden_Compare:
         }
 
     RETURN_TYPES = ("BOOLEAN",)
-    RETURN_NAMES = "BOOLEAN"
+    RETURN_NAMES = ("BOOLEAN",)
     FUNCTION = "compare"
     CATEGORY = "Eden 🌱/Logic"
 
@@ -144,7 +144,7 @@ class Eden_IfExecute:
         }
 
     RETURN_TYPES = (AlwaysEqualProxy("*"),)
-    RETURN_NAMES = "?"
+    RETURN_NAMES = ("?",)
     FUNCTION = "return_based_on_bool"
     CATEGORY = "Eden 🌱/Logic"
 


### PR DESCRIPTION
ComfyUI updates require that the RETURN_NAMES of custom nodes, if provided, must be a tuple, otherwise the node will be silently ignored. After updating to the latest ComfyUI, Eden_Compare and Eden_IfExecute will be missing for this reason, so here is a correction to the type to meet the requirements.